### PR TITLE
[in progress] Fix walletconnect integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@ensdomains/react-ens-address": "^0.0.30",
     "@metamask/jazzicon": "^2.0.0",
     "@usedapp/core": "^0.5.4",
-    "@walletconnect/web3-provider": "^1.6.5",
+    "@walletconnect/web3-provider": "^1.6.6",
     "@web3-react/core": "^6.1.9",
     "@web3-react/injected-connector": "^6.0.7",
     "@web3-react/walletconnect-connector": "^6.2.4",

--- a/src/contexts/utils/launchModalLazy.ts
+++ b/src/contexts/utils/launchModalLazy.ts
@@ -1,12 +1,13 @@
 import WalletConnectProvider from "@walletconnect/web3-provider";
 import Web3Modal from "web3modal";
-import { alchemyURL } from "src/utils";
+import { alchemyMainnetURL, alchemyRinkebyURL } from "src/utils";
 
 // ** Launch a Lazy Modal **
-const launchModalLazy = (
+async function launchModalLazy(
   t: (text: string, extra?: any) => string,
   cacheProvider: boolean = true
-) => {
+) {
+  console.log(localStorage.getItem("walletconnect"));
   const providerOptions = {
     injected: {
       display: {
@@ -15,10 +16,11 @@ const launchModalLazy = (
       package: null,
     },
     walletconnect: {
-      package: WalletConnectProvider.default,
+      package: WalletConnectProvider,
       options: {
         rpc: {
-          1: alchemyURL,
+          1: alchemyMainnetURL,
+          4: alchemyRinkebyURL,
         },
       },
       display: {
@@ -31,7 +33,7 @@ const launchModalLazy = (
     localStorage.removeItem("WEB3_CONNECT_CACHED_PROVIDER");
     localStorage.removeItem("walletconnect");
   }
-
+  
   const web3Modal = new Web3Modal({
     cacheProvider,
     providerOptions,
@@ -43,8 +45,7 @@ const launchModalLazy = (
       hover: "#000000",
     },
   });
-
-  return web3Modal.connect();
+  return await web3Modal.connect();
 };
 
 export default launchModalLazy;

--- a/src/utils/Web3Providers.ts
+++ b/src/utils/Web3Providers.ts
@@ -1,11 +1,14 @@
-export const alchemyURL = `https://eth-mainnet.alchemyapi.io/v2/${
+export const alchemyMainnetURL = `https://eth-mainnet.alchemyapi.io/v2/${
+  process.env.ALCHEMY_PROD_API_KEY ? process.env.ALCHEMY_PROD_API_KEY : ""
+}`;
+export const alchemyRinkebyURL = `https://eth-rinkeby.alchemyapi.io/v2/${
   process.env.ALCHEMY_PROD_API_KEY ? process.env.ALCHEMY_PROD_API_KEY : ""
 }`;
 export const testnetURL = `http://localhost:8545`;
 
 export function chooseBestWeb3Provider() {
   if (typeof window === "undefined") {
-    return alchemyURL;
+    return alchemyMainnetURL;
   }
 
   if (window.ethereum) {
@@ -13,6 +16,6 @@ export function chooseBestWeb3Provider() {
   } else if (window.web3) {
     return window.web3.currentProvider;
   } else {
-    return alchemyURL;
+    return alchemyMainnetURL;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3245,7 +3245,7 @@
     js-sha3 "0.8.0"
     query-string "6.13.5"
 
-"@walletconnect/web3-provider@^1.6.5":
+"@walletconnect/web3-provider@^1.6.6":
   version "1.6.6"
   resolved "https://registry.yarnpkg.com/@walletconnect/web3-provider/-/web3-provider-1.6.6.tgz#7be7b6d6230d6925f8728cdddc226ef24119e602"
   integrity sha512-8z4r9JCE0lKuZmVCPSdYnX114ckQ+oMfr9D8osRBtdyhvN9elwITMloUJfACDRelcuet94yEbXuDobQeBDDkkw==


### PR DESCRIPTION
* alchemy key needs to get added in '.env.local' in order for Next to pick it up. But in order to work it is exposed to the browser, not sure if this is safe or not lol https://nextjs.org/docs/basic-features/environment-variables#exposing-environment-variables-to-the-browser

- [x] * Display web3modal to give option to connect to walletconnect
- [x] * Test walletconnect connect/disconnect on mainnet. Hm. It also does not work smoothly on Rari dapp, which is what this code is forked from.
   - [x] SBAT: connect via walletconnect. On mobile disconnect, should show disconnected on reload. On dapp disconnect, only stays 'disconnected' on dapp but not actually on wallet.
- [ ] not showing ETH balance correctly on walletconnect
- [ ] Test walletconnect connect/disconnect on testnet. Walletconnect x Rainbow on testnet not working lol....  But I think this is Rainbow's fault & not my fault. Rainbow testnet walletconnect also doesn't work on Uniswap either
- [ ] test transaction walletconnect
- [ ] * "Connected to MetaMask/Walletconnect/etc" text update
- [ ] * Disconnect -> Change
- [ ] add walletconnect icon
<img width="462" alt="Screen Shot 2022-01-21 at 12 31 04 AM" src="https://user-images.githubusercontent.com/27475332/150494853-9cf0ca5b-86a4-46f8-8af1-55ef5c6f1d26.png">

