### PR TITLE
:gear: hover styling ocd

### DIFF
--- a/src/components/projectgrid/ProjectCard.tsx
+++ b/src/components/projectgrid/ProjectCard.tsx
@@ -33,20 +33,17 @@ const ProjectCard = ({ project, chainId }) => {
 
   return (
     <a href={projectIdLink}>
-      <div className="flex flex-col pb-3 overflow-hidden bg-gray-800 rounded shadow-sm">
-        <div className="flex-grow w-full text-center ">
-          <a
-            href={projectIdLink}
-            className="block mb-5 -mx-2 -mt-2 transition duration-200 ease-out origin-bottom transform hover:scale-105 hover:shadow-xl active:shadow active:opacity-50"
-          >
-            <Image
-              src={project.image_src}
-              alt="Photo"
-              className="inline-block rounded"
-              width={100}
-              height={100}
-            />
-          </a>
+      <div className="flex flex-col overflow-hidden bg-gray-800 rounded shadow-sm">
+        <div
+          className="flex-grow w-full text-center block pb-6 -mt-2 pt-10 transition duration-200 ease-out origin-bottom transform hover:scale-105 hover:shadow-xl active:shadow active:opacity-50"
+        >
+          <Image
+            src={project.image_src}
+            alt="Photo"
+            className="inline-block rounded"
+            width={100}
+            height={100}
+          />
           <h3 className="text-lg font-semibold text-gray-200">
             {project.title}
           </h3>


### PR DESCRIPTION
This PR cleans up the Project Card hover effects to remove overflow and expand all card contents.

![Screenshot from 2022-03-02 12-49-59](https://user-images.githubusercontent.com/21288394/156448744-368d1523-a708-491b-942b-bd339d761187.png)
